### PR TITLE
Added support for `coc.nvim` or other LSP providers

### DIFF
--- a/lua/lua-dev/sumneko.lua
+++ b/lua/lua-dev/sumneko.lua
@@ -63,9 +63,10 @@ function M.types()
 end
 
 function M.setup(opts)
-  local lspconfig = require("lspconfig")
+  local ok, lspconfig = pcall(require, "lspconfig")
+
   return {
-    on_new_config = lspconfig.util.add_hook_after(
+    on_new_config = ok and lspconfig.util.add_hook_after(
       lspconfig.util.default_config.on_new_config,
       function(config, root_dir)
         -- remove the root_dir from the workspace, otherwise diagnostics break. See #21


### PR DESCRIPTION
If a user chooses not to use `lspconfig`, then this plugin is unusable. I added a check to make sure that `lspconfig` is installed before it is required. This way people are able to configure something like `coc.nvim` to support this plugin.

I use `packer` and am unsure how to check whether or not `lspconfig` is supported with `paq`. So I just checked whether or not it had been picked up by Lua itself instead.